### PR TITLE
Fix README.md repository URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,13 +14,13 @@ A simple Bash script for managing the Nosana Node as a `systemd` service on Linu
     Open your terminal and clone this repository to your machine.
 
     ```bash
-    git clone https://github.com/nosana-ci/service-manager.git
+    git clone https://github.com/Pukerud/NosanaMenu.git
     ```
 
 2.  **Navigate to the directory**
 
     ```bash
-    cd service-manager
+    cd NosanaMenu
     ```
 
 3.  **Make the script executable**


### PR DESCRIPTION
Updated the README.md to point to the correct repository URL (https://github.com/Pukerud/NosanaMenu.git) and directory name (NosanaMenu) for cloning and navigation.