### PR TITLE
Fix: Update README run command to handle existing repo

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ A simple Bash script for managing the Nosana Node as a `systemd` service on Linu
 Open your terminal and run the following command to clone the repository, navigate into the directory, make the setup script executable, and run it. This single command automates the initial setup process. It will prompt for your `sudo` password if required for the script execution.
 
 ```bash
-git clone https://github.com/Pukerud/NosanaMenu.git && cd NosanaMenu && chmod +x setup.sh && ./setup.sh
+if [ -d "NosanaMenu" ]; then cd NosanaMenu && git pull && chmod +x setup.sh && ./setup.sh; else git clone https://github.com/Pukerud/NosanaMenu.git && cd NosanaMenu && chmod +x setup.sh && ./setup.sh; fi
 ```
 
 ## Menu Options


### PR DESCRIPTION
The command in the README.md for setting up and running NosanaMenu has been updated.

The new command checks if the 'NosanaMenu' directory already exists. If it does, it navigates into the directory, pulls the latest changes from the repository, ensures the setup script is executable, and then runs the setup script.
If the directory does not exist, it clones the repository, navigates into the new directory, makes the setup script executable, and then runs it.

This change addresses an issue where the previous command would fail if the repository had already been cloned.