### PR TITLE
Integrate screen for Nosana service management

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,9 +27,12 @@ This option creates a `systemd` service file for the Nosana Node. It will:
 *   Enable the service to start automatically on boot.
 *   Start the service immediately.
 
-### 2. View current status
-This option displays a live log from the Nosana service. It uses `journalctl` to stream the output directly to your terminal, which is useful for monitoring the node's activity in real-time.
-*   Press `Ctrl+C` to exit the log view and return to the menu.
+### 2. View Live Status (via Screen)
+This option allows you to view the live output of the Nosana Node, which now runs in a `screen` session.
+*   The service runs in a detached `screen` session named `nosana`.
+*   To attach to this session and view the live output, the script will run `screen -r nosana`.
+*   To detach from the screen session (and keep the node running in the background), press `Ctrl+A` then `D`.
+*   After detaching, you'll be prompted to press Enter to return to the menu.
 
 ### 3. Disable service
 This option stops the running Nosana service and disables it from starting automatically on boot.

--- a/setup.sh
+++ b/setup.sh
@@ -42,6 +42,10 @@ install_service() {
         return 1
     fi
 
+    # Installer screen
+    echo "Installing screen..."
+    sudo apt-get update && sudo apt-get install -y screen
+
     # Opprett tjenestefilen med sudo
     sudo tee "$SERVICE_FILE" > /dev/null <<EOF
 [Unit]
@@ -53,7 +57,7 @@ Wants=network-online.target
 # DENNE KOMMANDOEN ER LØSNINGEN:
 # Vi tvinger shellen til å være INTERAKTIV (-i)
 # Dette skaper et miljø som er identisk med en manuell kjøring.
-ExecStart=/bin/bash -ic "bash <(wget -qO- https://nosana.com/start.sh)"
+ExecStart=/usr/bin/screen -d -m -S nosana bash -c "wget -qO- https://nosana.com/start.sh | bash"
 
 User=$NOSANA_USER
 Restart=always
@@ -78,12 +82,12 @@ EOF
 
 # Funksjon for å se live logg
 view_log() {
-    echo "Showing live log for ${SERVICE_NAME}..."
-    echo "Press Ctrl+C to exit the log view."
+    echo "Attempting to attach to screen session 'nosana'..."
+    echo "Press Ctrl+A then D to detach from the screen session."
     echo "-----------------------------------------"
-    journalctl -u ${SERVICE_NAME} -f
+    screen -r nosana
     echo ""
-    echo "Log view exited. Press Enter to return to the menu."
+    echo "Screen session detached. Press Enter to return to the menu."
     read
 }
 


### PR DESCRIPTION
This commit modifies the Nosana service setup to use `screen` for managing the Nosana process.

Key changes:
- The `install_service` function in `setup.sh` now automatically installs `screen` using `apt-get`.
- The systemd service (`nosana.service`) now runs the Nosana script within a detached `screen` session named "nosana". The `ExecStart` command has been updated to `/usr/bin/screen -d -m -S nosana bash -c "wget -qO- https://nosana.com/start.sh | bash"`.
- The `view_log` function in `setup.sh` (renamed to "View Live Status / Attach to Screen") now uses `screen -r nosana` to allow you to attach to the running screen session and view the live status. Instructions are provided on how to detach from the screen session.
- The `README.md` has been updated to reflect these changes, including instructions on how to attach to and detach from the `screen` session.