### PR TITLE
Fix: Improve screen session handling and add service status option

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,37 +22,46 @@ After running the script, you will see a menu with the following options:
 
 ### 1. Install Nosana Auto Start
 This option creates a `systemd` service file for the Nosana Node. It will:
-*   Place a service file in `/etc/systemd/system/nosana.service`.
+*   Prompt for a username to run the service (must be in the `docker` group).
+*   Install `screen` if it's not already present.
+*   Place a service file in `/etc/systemd/system/nosana.service`. The service is configured to run the Nosana start script within a detached `screen` session named `nosana` (e.g., `ExecStart=/usr/bin/screen -S nosana -dm bash -c "wget -qO- https://nosana.com/start.sh | bash"`).
 *   Reload `systemd`.
 *   Enable the service to start automatically on boot.
 *   Start the service immediately.
 
-### 2. View Live Status (via Screen)
-This option allows you to view the live output of the Nosana Node, which now runs in a `screen` session.
-*   The service runs in a detached `screen` session named `nosana`.
-*   To attach to this session and view the live output, the script will run `screen -r nosana`.
-*   To detach from the screen session (and keep the node running in the background), press `Ctrl+A` then `D`.
-*   After detaching, you'll be prompted to press Enter to return to the menu.
+### 2. View Live Status / Attach to Screen
+This option allows you to connect to the `screen` session where the Nosana Node is running.
+*   It first reads the `/etc/systemd/system/nosana.service` file to determine the `User` the service (and thus the screen session) runs as.
+*   It then checks if a `screen` session named `nosana` exists for that user (e.g., using `sudo -u <USER> screen -ls | grep '\.nosana'`).
+*   If the session is found, it will attempt to attach to it using `sudo -u <USER> screen -r nosana`.
+*   If the session is not found, an informative message will be displayed, guiding you to check the service status or logs.
+*   To detach from the screen session (leaving the Nosana Node running in the background), press `Ctrl+A` then `D`.
+*   After detaching or if the session was not found, you'll be prompted to press Enter to return to the menu.
 
-### 3. Disable service
+### 3. Check Nosana Service Status
+This option displays the current status of the `nosana.service` using `systemd`.
+*   It runs the command `systemctl status nosana.service --no-pager` for a concise output.
+*   This is useful for quickly verifying if the service is active, failed, or to see recent log entries from `journald` related to the service.
+
+### 4. Disable Service
 This option stops the running Nosana service and disables it from starting automatically on boot.
 
-### 4. Enable service
+### 5. Enable Service
 This option will enable the Nosana service to start on boot and start it immediately. Useful if you have previously disabled it.
 
-### 5. Update Environment Variables
+### 6. Update Environment Variables
 This option allows you to update the environment variables for the Nosana Node. It will:
 *   Prompt you to enter the new environment variables.
 *   Update the `nosana.service` file with the new environment variables.
 *   Reload `systemd`.
 *   Restart the Nosana service to apply the changes.
 
-### 6. Update Node
+### 7. Update Node
 This option allows you to update the Nosana Node to the latest version. It will:
 *   Stop the Nosana service.
 *   Download the latest version of the Nosana Node.
 *   Replace the existing Nosana Node executable with the new version.
 *   Start the Nosana service.
 
-### 7. Exit
+### 8. Exit
 Exits the script.


### PR DESCRIPTION
This commit addresses issues with screen session detection and enhances the Nosana service management script.

Key changes:

- Modified `install_service` in `setup.sh`:
    - Refined `ExecStart` for more reliable screen session creation.
- Modified `view_log` (now "View Live Status / Attach to Screen") in `setup.sh`:
    - Parses `NOSANA_USER` from the `nosana.service` file.
    - Checks if the screen session exists for `NOSANA_USER` before attempting to attach.
    - Attaches using `sudo -u $NOSANA_USER screen -r nosana`.
    - Displays an informative message if the session is not found.
    - Updated menu option text.
- Added `check_service_status` function and menu option in `setup.sh`:
    - New option "3. Check Nosana Service Status" runs `systemctl status nosana.service --no-pager`.
    - Menu options renumbered accordingly.
- Updated `README.md`:
    - Documented all changes to script behavior, screen session management, new menu options, and troubleshooting.