### PR TITLE
Fix: Add screen -wipe to resolve dead session issues

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,8 @@ This option creates a `systemd` service file for the Nosana Node. It will:
 ### 2. View Live Status / Attach to Screen
 This option allows you to connect to the `screen` session where the Nosana Node is running.
 *   It first reads the `/etc/systemd/system/nosana.service` file to determine the `User` the service (and thus the screen session) runs as.
-*   It then checks if a `screen` session named `nosana` exists for that user (e.g., using `sudo -u <USER> screen -ls | grep '\.nosana'`).
+*   Before checking for an active session, the script attempts to clean up any dead screen session listings for that user by running `sudo -u <USER> screen -wipe`. This helps improve reliability if previous sessions did not terminate cleanly.
+*   It then checks if an active `screen` session named `nosana` exists for that user (e.g., using `sudo -u <USER> screen -ls | grep '[0-9]+\.nosana\s+(Attached|Detached)'`).
 *   If the session is found, it will attempt to attach to it using `sudo -u <USER> screen -r nosana`.
 *   If the session is not found, an informative message will be displayed, guiding you to check the service status or logs.
 *   To detach from the screen session (leaving the Nosana Node running in the background), press `Ctrl+A` then `D`.

--- a/setup.sh
+++ b/setup.sh
@@ -105,21 +105,24 @@ view_log() {
 
     echo "Service is configured to run as user: $NOSANA_USER"
 
+    echo "Cleaning up dead screen sessions (if any) for user $NOSANA_USER..."
+    sudo -u "$NOSANA_USER" screen -wipe >/dev/null 2>&1 # Suppress output unless there's an error from sudo itself
+
     # Check if screen session exists for the NOSANA_USER
-    # The grep output is suppressed by -q, we only care about the exit status.
-    if sudo -u "$NOSANA_USER" screen -ls | grep -q "\.nosana"; then # screen names are prefixed with PID
+    # grep for a line that starts with a PID (digits), then a dot, then "nosana" and is marked (Attached) or (Detached)
+    if sudo -u "$NOSANA_USER" screen -ls | grep -q -E "[0-9]+\.nosana\s+\((Attached|Detached)\)"; then
         echo "Found active Nosana screen session. Attaching..."
         echo "Press Ctrl+A then D to detach from the screen session."
         echo "-----------------------------------------"
         # Attach to the screen session as the NOSANA_USER
         sudo -u "$NOSANA_USER" screen -r nosana
         echo "-----------------------------------------"
-        echo "Screen session detached. Press Enter to return to the menu."
+        echo "Screen session detached." # This message appears after successful detach
     else
-        echo "Nosana screen session 'nosana' is not running or not found for user '$NOSANA_USER'."
-        echo "You can try starting/enabling the service (Option 4)."
+        echo "Nosana screen session 'nosana' is not running or could not be uniquely identified for user '$NOSANA_USER'."
+        echo "You can try starting/enabling the service (Option 5 in the menu)." # Adjusted option number
         echo "For detailed service logs, you can use: journalctl -u ${SERVICE_NAME}"
-        echo "If the service is running but the screen session is missing, it might indicate an issue during service startup."
+        echo "Or check the overall service status (Option 3 in the menu)."      # Adjusted option number
     fi
     echo ""
     echo "Press Enter to return to the menu."


### PR DESCRIPTION
This commit further improves the Nosana service management script by addressing issues caused by dead screen sessions.

Key changes:

- Modified `view_log` function in `setup.sh`:
    - Added `sudo -u $NOSANA_USER screen -wipe` before checking for active sessions. This cleans up dead screen entries that were preventing `screen -r nosana` from correctly identifying the live session.
    - Refined the pattern for detecting active screen sessions to `[0-9]+\.nosana\s+\((Attached|Detached)\)` for better accuracy.
    - Updated informational messages to you.
- Updated `README.md`:
    - Documented the automatic `screen -wipe` process in the "View Live Status / Attach to Screen" section.
    - Updated the example pattern in the README to match the script.