### PR TITLE
Fix: Address service restart loop and add version tag

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Nosana Service Manager
 
-A simple Bash script for managing the Nosana Node as a `systemd` service on Linux. This allows the Nosana Node to start automatically at boot and simplifies its management.
+A simple Bash script for managing the Nosana Node as a `systemd` service on Linux. This allows the Nosana Node to start automatically at boot and simplifies its management. The script's menu now also displays its version number for easier reference when seeking support or tracking updates.
 
 ## Prerequisites
 
@@ -24,7 +24,7 @@ After running the script, you will see a menu with the following options:
 This option creates a `systemd` service file for the Nosana Node. It will:
 *   Prompt for a username to run the service (must be in the `docker` group).
 *   Install `screen` if it's not already present.
-*   Place a service file in `/etc/systemd/system/nosana.service`. The service is configured to run the Nosana start script within a detached `screen` session named `nosana` (e.g., `ExecStart=/usr/bin/screen -S nosana -dm bash -c "wget -qO- https://nosana.com/start.sh | bash"`).
+*   Place a service file in `/etc/systemd/system/nosana.service`. The service is configured to run the Nosana start script within a detached `screen` session named `nosana` (e.g., `ExecStart=/usr/bin/screen -S nosana -dm bash -ic "wget -qO- https://nosana.com/start.sh | bash; exec bash"`).
 *   Reload `systemd`.
 *   Enable the service to start automatically on boot.
 *   Start the service immediately.

--- a/setup.sh
+++ b/setup.sh
@@ -3,12 +3,13 @@
 # Definer navnet på tjenesten
 SERVICE_NAME="nosana.service"
 SERVICE_FILE="/etc/systemd/system/${SERVICE_NAME}"
+SCRIPT_VERSION="1.0.0"
 
 # Funksjon for å vise menyen
 show_menu() {
     clear
     echo "========================================="
-    echo "      Nosana Service Manager"
+    echo "      Nosana Service Manager v${SCRIPT_VERSION}"
     echo "========================================="
     echo "1. Install Nosana Auto-Start Service"
     echo "2. View Live Status / Attach to Screen"
@@ -58,7 +59,7 @@ Wants=network-online.target
 # DENNE KOMMANDOEN ER LØSNINGEN:
 # Vi tvinger shellen til å være INTERAKTIV (-i)
 # Dette skaper et miljø som er identisk med en manuell kjøring.
-ExecStart=/usr/bin/screen -S nosana -dm bash -c "wget -qO- https://nosana.com/start.sh | bash"
+ExecStart=/usr/bin/screen -S nosana -dm bash -ic "wget -qO- https://nosana.com/start.sh | bash; exec bash"
 
 User=$NOSANA_USER
 Restart=always


### PR DESCRIPTION
This commit attempts to resolve the service 'activating (auto-restart)' issue by modifying the ExecStart command to keep the screen session alive. It also adds a version number to the script's menu display.

Key changes:

- Modified `install_service` function in `setup.sh`:
    - Changed `ExecStart` to `/usr/bin/screen -S nosana -dm bash -ic "wget -qO- https://nosana.com/start.sh | bash; exec bash"`. The `-i` flag for bash and the trailing `exec bash` are intended to keep the interactive shell within screen running, thus preventing the service from exiting immediately.
- Added Version Tag in `setup.sh`:
    - Defined `SCRIPT_VERSION="1.0.0"` at the top of the script.
    - Updated `show_menu` to display this version (e.g., "Nosana Service Manager v1.0.0").
- Updated `README.md`:
    - Mentioned the new script version display in the introduction.
    - Updated the example `ExecStart` command in the installation section to reflect the change.