### PR TITLE
feat: Implement screen setup with simplified menu

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -2,36 +2,11 @@
 set -e
 set -u
 
-# --- Dynamic TARGET_USER determination for menu display and service name construction ---
-if [ -n "${SUDO_USER:-}" ] && [ "$SUDO_USER" != "root" ]; then
-    TARGET_USER="$SUDO_USER"
-elif [ "$(logname)" != "root" ] && [ -n "$(logname)" ]; then
-    TARGET_USER="$(logname)"
-else
-    # Fallback if no suitable user is found for constructing service names.
-    # The individual setup_nosana_screen.sh will do more rigorous checks.
-    echo "INFO: Could not determine a specific non-root user for service name generation. Defaulting to 'user'."
-    echo "      If a service was installed for a specific user, its name might not match menu defaults."
-    TARGET_USER="user" # A generic fallback for menu display
-fi
-echo "INFO: Menu commands will be targeted for user: $TARGET_USER"
-
-# Also find screen path for the attach command
-SCREEN_PATH=$(which screen)
-if [ -z "$SCREEN_PATH" ]; then
-    echo "WARNING: 'screen' command not found. Option 2 (Attach to screen) might not work."
-    # Don't exit, as other menu options might still be useful.
-fi
-# --- End of TARGET_USER determination ---
-
-# Definer navnet på tjenesten og screen-sesjonen (bruker-spesifikk)
-SERVICE_NAME="nosana-${TARGET_USER}.service"
-SCREEN_SESSION_NAME="nosana_${TARGET_USER}"
-# SERVICE_FILE is not strictly needed globally anymore as setup_nosana_screen.sh handles its own path logic
-# However, check_service_status and enable_service might use it if they check for file existence.
-# For now, let's define it for compatibility with any such checks.
-SERVICE_FILE_PATH="/etc/systemd/system/${SERVICE_NAME}" # For functions that might check file existence
-SCRIPT_VERSION="1.2.0" # Updated version for new screen integration
+# Set generic global names
+SERVICE_NAME="nosana.service" # Fixed generic name
+SCREEN_SESSION_NAME="nosana"  # Fixed generic name for screen sessions handled by attach_to_screen
+SERVICE_FILE_PATH="/etc/systemd/system/${SERVICE_NAME}" # Derived from generic SERVICE_NAME
+SCRIPT_VERSION="1.3.0"
 
 # Funksjon for å vise menyen
 show_menu() {
@@ -39,44 +14,25 @@ show_menu() {
     echo "========================================="
     echo "      Nosana Service Manager v${SCRIPT_VERSION}"
     echo "========================================="
-    echo " Target User: $TARGET_USER"
-    echo " Service Name: $SERVICE_NAME"
-    echo " Screen Session: $SCREEN_SESSION_NAME"
-    echo "-----------------------------------------"
+    # Removed display of Target User, specific Service Name, and specific Screen Session
     echo "1. Install/Reconfigure Nosana Service (via setup_nosana_screen.sh)"
-    echo "2. Attach to Nosana Screen (${SCREEN_SESSION_NAME})"
-    echo "3. Check Nosana Service Status (${SERVICE_NAME})"
-    echo "4. Disable and Stop Service (${SERVICE_NAME})"
-    echo "5. Enable and Start Service (${SERVICE_NAME})"
+    echo "2. Attach to Nosana Screen" # Generic name
+    echo "3. Check Nosana Service Status (${SERVICE_NAME})" # Generic service name
+    echo "4. Disable and Stop Service (${SERVICE_NAME})"   # Generic service name
+    echo "5. Enable and Start Service (${SERVICE_NAME})"   # Generic service name
     echo "6. Exit"
     echo "-----------------------------------------"
 }
 
 # Funksjon for å installere/konfigurere systemd-tjenesten via setup_nosana_screen.sh
 install_service() {
-    echo "INFO: Attempting to install/reconfigure the Nosana service using setup_nosana_screen.sh..."
-    echo "      This will run setup_nosana_screen.sh with sudo."
+    echo "INFO: This option will run setup_nosana_screen.sh with sudo."
+    echo "      The setup_nosana_screen.sh script will handle the specific user configuration."
     if [ -f ./setup_nosana_screen.sh ]; then
         sudo bash ./setup_nosana_screen.sh
-        echo "INFO: Installation script finished. Check its output for status."
-        # Refresh TARGET_USER and related names in case setup_nosana_screen.sh was run for a *different* user
-        # than initially detected by this menu script (e.g. if sudo was used with -u option).
-        # This is a best-effort for the menu, the actual service will be per setup_nosana_screen.sh's logic.
-        if [ -n "${SUDO_USER:-}" ] && [ "$SUDO_USER" != "root" ]; then
-            TARGET_USER="$SUDO_USER"
-        elif [ "$(logname)" != "root" ] && [ -n "$(logname)" ]; then
-            TARGET_USER="$(logname)"
-        else
-            TARGET_USER="user"
-        fi
-        SERVICE_NAME="nosana-${TARGET_USER}.service"
-        SCREEN_SESSION_NAME="nosana_${TARGET_USER}"
-        SERVICE_FILE_PATH="/etc/systemd/system/${SERVICE_NAME}"
-        echo "INFO: Menu service/screen names updated to reflect user '$TARGET_USER'."
-
+        echo "INFO: Installation script 'setup_nosana_screen.sh' finished."
     else
         echo "ERROR: setup_nosana_screen.sh not found in the current directory."
-        echo "       Please ensure it is present and try again."
     fi
     echo "Press Enter to return to the menu..."
     read -r
@@ -84,23 +40,34 @@ install_service() {
 
 # Funksjon for å koble til screen-sesjonen
 attach_to_screen() {
-    echo "INFO: Attempting to attach to screen session '$SCREEN_SESSION_NAME' for user '$TARGET_USER'..."
-    if [ -z "$SCREEN_PATH" ]; then
+    local DEFAULT_USER="octa" # Or another sensible default like the current non-sudo user
+    if [ -n "${SUDO_USER:-}" ] && [ "$SUDO_USER" != "root" ]; then
+        DEFAULT_USER="$SUDO_USER"
+    elif [ "$(logname)" != "root" ] && [ -n "$(logname)" ]; then
+        DEFAULT_USER="$(logname)"
+    fi
+
+    read -p "Enter username for the screen session (default: $DEFAULT_USER): " INPUT_USER
+    local TARGET_SCREEN_USER="${INPUT_USER:-$DEFAULT_USER}"
+
+    local screen_path
+    screen_path=$(which screen)
+
+    if [ -z "$screen_path" ]; then
         echo "ERROR: 'screen' command not found. Cannot attach."
     else
-        # Check if the screen session exists
-        # The -q option for grep suppresses output, we just need the exit status.
-        if sudo -u "$TARGET_USER" "$SCREEN_PATH" -ls | grep -q -E "[0-9]+\.${SCREEN_SESSION_NAME}\s+\((Attached|Detached)\)"; then
+        echo "INFO: Attempting to attach to screen session '$SCREEN_SESSION_NAME' as user '$TARGET_SCREEN_USER'..."
+        # Check if the screen session exists for that user
+        if sudo -u "$TARGET_SCREEN_USER" "$screen_path" -ls | grep -q -E "[0-9]+\.${SCREEN_SESSION_NAME}\s+\((Attached|Detached)\)"; then
             echo "INFO: Found active screen session. Attaching..."
             echo "      Press Ctrl+A then D to detach."
             echo "-----------------------------------------"
-            sudo -u "$TARGET_USER" "$SCREEN_PATH" -r "$SCREEN_SESSION_NAME"
+            sudo -u "$TARGET_SCREEN_USER" "$screen_path" -r "$SCREEN_SESSION_NAME"
             echo "-----------------------------------------"
             echo "INFO: Detached from screen session."
         else
-            echo "INFO: Screen session '$SCREEN_SESSION_NAME' for user '$TARGET_USER' not found or not running."
-            echo "      You can try starting/enabling the service (Option 5)."
-            echo "      For detailed service logs, use: journalctl -u $SERVICE_NAME"
+            echo "INFO: Screen session '$SCREEN_SESSION_NAME' for user '$TARGET_SCREEN_USER' not found or not running."
+            echo "      The service '$SERVICE_NAME' (if it points to this user's screen) might need to be started."
         fi
     fi
     echo "Press Enter to return to the menu..."
@@ -109,7 +76,7 @@ attach_to_screen() {
 
 # Funksjon for å sjekke tjenestestatus
 check_service_status() {
-    echo "INFO: Checking Nosana service status (${SERVICE_NAME})..."
+    echo "INFO: Checking Nosana service status (${SERVICE_NAME})..." # Uses generic SERVICE_NAME
     echo "-----------------------------------------"
     # Using systemctl status directly. If service doesn't exist, it will show that.
     systemctl status "${SERVICE_NAME}" --no-pager || true # ensure script doesn't exit if service not found


### PR DESCRIPTION
This commit finalizes the Nosana service setup using a screen-based method and simplifies the main menu script (`setup.sh`).

1.  **New `setup_nosana_screen.sh`**:
    *   Handles the complete installation and your user-specific configuration of the Nosana service.
    *   Dynamically determines `TARGET_USER` (from `SUDO_USER` or `logname`), preventing root service execution and ensuring Docker group membership.
    *   Installs 'screen' if needed (supports apt, yum, dnf).
    *   Creates user-specific files and service names:
        *   Start script: `/usr/local/bin/start_nosana_${TARGET_USER}.sh`
        *   Sudoers: `/etc/sudoers.d/90-nosana-${TARGET_USER}-permissions`
        *   Systemd service: `/etc/systemd/system/nosana-${TARGET_USER}.service`
        *   Screen session: `nosana_${TARGET_USER}`
    *   This script must be run as root.

2.  **Simplified `setup.sh` (Menu Script)**:
    *   The menu script (`setup.sh`) is now significantly simplified.
    *   Installation (Option 1) directly calls `sudo bash setup_nosana_screen.sh`.
    *   Other menu options (attach to screen, service status, stop/start) now refer to generic, fixed names (`nosana.service`, screen session "nosana").
    *   For attaching to a screen session, `setup.sh` prompts you for the target username, as `setup_nosana_screen.sh` handles the user-specific setup.
    *   Removed complex dynamic user determination from `setup.sh`'s global scope and menu display, deferring specifics to `setup_nosana_screen.sh`.
    *   Script version updated to 1.3.0.

3.  **Removed `nosana_config.sh`**:
    *   The previous script for a direct systemd setup was removed.

This approach delegates the detailed, user-specific configuration to `setup_nosana_screen.sh`, while `setup.sh` acts as a simpler launcher and generic interaction menu.