### PR TITLE
Fix: Standardize Nosana screen session name to 'nosana'

### DIFF
--- a/setup_nosana_screen.sh
+++ b/setup_nosana_screen.sh
@@ -49,7 +49,7 @@ echo "INFO: TARGET_USER is '$TARGET_USER' and is a member of the 'docker' group.
 START_SCRIPT_PATH="/usr/local/bin/start_nosana_${TARGET_USER}.sh"
 SUDOERS_FILE="/etc/sudoers.d/90-nosana-${TARGET_USER}-permissions"
 SERVICE_FILE_PATH="/etc/systemd/system/nosana-${TARGET_USER}.service"
-SCREEN_SESSION_NAME="nosana_${TARGET_USER}"
+SCREEN_SESSION_NAME="nosana"
 
 # --- Forberedelser ---
 echo "🚀 Starter konfigurasjon for Nosana med screen-metoden..."


### PR DESCRIPTION
The `setup_nosana_screen.sh` script was previously creating screen sessions named 'nosana_${TARGET_USER}', e.g., 'nosana_octa'. However, the related `setup.sh` menu script and common user expectation pointed towards a simpler screen name 'nosana'.

This change modifies `setup_nosana_screen.sh` to:
- Use the fixed screen session name "nosana" internally.
- Update the systemd service configuration (ExecStart/ExecStop) to refer to "nosana".
- Adjust the informational message provided to you to correctly state the command for attaching: `sudo -u $TARGET_USER screen -r nosana`.

The `setup.sh` script's "Attach to Nosana Screen" option already defaults to using "nosana" as the screen name and is now fully aligned with the session created by `setup_nosana_screen.sh`.

This resolves the issue where the expected command `sudo -u octa screen -r nosana` would not work if the target user was 'octa', as the session would have been 'nosana_octa'. The underlying service and start scripts remain user-specific (e.g., `nosana-octa.service`), but the screen session name itself is now standardized.